### PR TITLE
Split

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -27,16 +27,9 @@ func Example() {
 	for _, s := range paths {
 
 		// ParsePath parses a JSON path expression into a Path: a sequence of Steps
-		path, err := jsonpath.ParsePath(s)
+		jpath, err := jsonpath.Compile(s)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "example: path %q: %s\n", s, err)
-			continue
-		}
-
-		// Path.Compile then converts a Path and its expressions into a Program for a simple abstract machine.
-		prog, err := path.Compile()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "example: path %q: compilation error: %s\n", s, err)
 			continue
 		}
 		fmt.Printf("pattern: %s\n", s)
@@ -48,9 +41,9 @@ func Example() {
 				continue
 			}
 
-			// Program.Run evaluates prog on a given JSON value, the root of a document, returning
-			// the list of resulting JSON values. The same program can be reused, even concurrently.
-			vals, err := prog.Run(d)
+			// jpath.Eval evaluates the path s on a given JSON value, the root of a document, returning
+			// the list of resulting JSON values. The same JSONPath value can be reused, even concurrently.
+			vals, err := jpath.Eval(d)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "example: path %q: subject %q: %s\n", s, doc, err)
 				continue

--- a/jsonpath.go
+++ b/jsonpath.go
@@ -1,0 +1,81 @@
+// Copyright © 2021-22 Charles Forsyth (charles.forsyth@gmail.com)
+// Usable under the terms in the file LICENSE.
+
+// Package jsonpath provides a parser and evaluator for JSONpaths, a syntax for expressing queries and locations in a JSON structure.
+// Given a JSON value ("document") a path expression selects subcomponents and returns a list of the selected values.
+//
+// The JSONpath syntax is often defined by providing a set of sample paths.
+// Following https://github.com/dchester/jsonpath/, this package instead is based on a grammar,
+// Briefly, a JSONpath gives a dot-separated path through a JSON structure, with nested expressions providing dynamic values and filters.
+// Unfortunately the notation has not yet been standardised, and implementations have signfiicant differences.
+// This one aims to satisfy the existing consensus as represented by several test suites.
+//
+// For the detailed syntax, run
+//	go doc jsonpath/syntax
+package jsonpath
+
+import (
+	"strconv"
+
+	"github.com/forsyth/jsonpath/mach"
+	"github.com/forsyth/jsonpath/paths"
+)
+
+// JSONPath represents a compiled  JSONpath expression.
+// It is safe for concurrent use by goroutines.
+type JSONPath struct {
+	expr string        // as passed to Compile
+	path *paths.Path   // the parsed expression
+	prog *mach.Program // the program for the abstract machine
+}
+
+// String returns the source text used to compile the JSONpath expression.
+func (path *JSONPath) String() string {
+	return path.expr
+}
+
+// Compile parses a JSONpath expression and, if successful, returns a JSONPath value
+// that allows repeated evaluation of that expression against a given JSON value.
+func Compile(expr string) (*JSONPath, error) {
+	path, err := paths.ParsePath(expr)
+	if err != nil {
+		return nil, err
+	}
+	prog, err := mach.Compile(path)
+	if err != nil {
+		return nil, err
+	}
+	return &JSONPath{expr: expr, prog: prog}, nil
+}
+
+// MustCompile is like Compile but panics if the expression is invalid.
+func MustCompile(expr string) *JSONPath {
+	p, err := Compile(expr)
+	if err != nil {
+		panic(`jsonpath: Compile(` + quote(expr) + `): ` + err.Error())
+	}
+	return p
+}
+
+func quote(s string) string {
+	if strconv.CanBackquote(s) {
+		return "`" + s + "`"
+	}
+	return strconv.Quote(s)
+}
+
+// Eval evaluates a previously-compiled JSONpath expression against a given JSON value
+// (the root of a document), as returned by encoding/json.Decoder.Unmarshal.
+// It returns a slice containing the list of the JSON values selected by the path expression.
+// If a run-time error occurs, for instance an invalid dynamic regular expression,
+// Eval stops and returns only an error.
+// Eval may be used concurrently.
+//
+// Path expressions contain boolean filter expressions of the form ?(expr), and other
+// numeric, string or boolean expressions of the form (expr). The expression language
+// is the same for each, containing a subset of JavaScript's expression and logical
+// operators, and a match operator ~ (subject-string ~ /re/ or subject-string ~ regexp-string).
+// The equality operators == and != apply JavaScript's equality rules.
+func (path *JSONPath) Eval(root interface{}) ([]interface{}, error) {
+	return path.prog.Run(root)
+}

--- a/mach/fns.go
+++ b/mach/fns.go
@@ -1,4 +1,4 @@
-package jsonpath
+package mach
 
 import (
 	"math"
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode/utf8"
+	//	"github.com/forsyth/jsonpath/paths"
 )
 
 // Function represents a predefined function with na args (or AnyNumber) with body fn.

--- a/mach/json.go
+++ b/mach/json.go
@@ -1,4 +1,4 @@
-package jsonpath
+package mach
 
 import (
 	"encoding/json"
@@ -6,11 +6,13 @@ import (
 	"math"
 	"strconv"
 	"strings"
+
+	"github.com/forsyth/jsonpath/paths"
 )
 
 // JSON is a synonym for the interface{} structures returned by encoding/json,
 // used as values in the JSON machine, to make it clear that's what they are.
-type JSON = interface{}
+type JSON = paths.JSON // temporary, during the renaming
 
 // enquiry functions on JSON, sometimes easier to read than type switches
 
@@ -38,7 +40,7 @@ func isFloat(v JSON) bool {
 
 // isSlice returns true if v represents slice parameters.
 func isSlice(v JSON) bool {
-	_, ok := v.(*Slice)
+	_, ok := v.(*paths.Slice)
 	return ok
 }
 
@@ -310,7 +312,7 @@ func cvi(v JSON) int64 {
 			return 0
 		}
 		return n
-	case IntVal: // appears in Slice (via OpBounds)
+	case paths.IntVal: // appears in Slice (via OpBounds)
 		return v.V()
 	default:
 		return 0
@@ -382,8 +384,8 @@ const (
 )
 
 // typeOf returns the  for a value, for use in Abstract Equality Comparison.
-func typeOf(js JSON) jsType {
-	switch js.(type) {
+func typeOf(v JSON) jsType {
+	switch v.(type) {
 	case error:
 		return Undefined
 	case nil:

--- a/mach/json_test.go
+++ b/mach/json_test.go
@@ -1,8 +1,9 @@
-package jsonpath
+package mach
 
 import (
 	"math"
 	"testing"
+	//	"github.com/forsyth/jsonpath/paths"
 )
 
 type args []JSON

--- a/mach/text.go
+++ b/mach/text.go
@@ -1,0 +1,57 @@
+package mach
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/forsyth/jsonpath/paths"
+)
+
+// String returns a representation of the text of the abstract machine program.
+func (prog *Program) String() string {
+	var sb strings.Builder
+	for i, val := range prog.vals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(val.String())
+	}
+	if len(prog.vals) > 0 {
+		sb.WriteByte(' ')
+	}
+	for i, ord := range prog.orders {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		op := ord.op()
+		sb.WriteString(trimOp(op))
+		if op.IsLeaf() {
+			if !op.HasVal() {
+				continue
+			}
+			if ord.isSmallInt() {
+				sb.WriteByte('(')
+				sb.WriteString(fmt.Sprint(ord.smallInt()))
+				sb.WriteByte(')')
+			} else {
+				sb.WriteByte('[')
+				sb.WriteString(fmt.Sprint(ord.index()))
+				sb.WriteByte(']')
+			}
+			continue
+		}
+		if ord.isSmallInt() && ord.smallInt() != 0 {
+			sb.WriteByte('.')
+			sb.WriteString(fmt.Sprint(ord.smallInt()))
+		}
+	}
+	return sb.String()
+}
+
+func trimOp(op paths.Op) string {
+	name := fmt.Sprintf("%#v", op)
+	if name == "" {
+		panic("unknown op in opNames")
+	}
+	return name[2:]
+}

--- a/mkfile
+++ b/mkfile
@@ -1,0 +1,16 @@
+SHELL=/bin/rc
+STRINGS=\
+	paths/op_string.go \
+
+all:V: $STRINGS
+	go build
+	go vet . ./paths ./mach
+
+paths/op_string.go:D: paths/ops.go
+	go generate paths/ops.go
+
+fmt:V:
+	go fmt . ./paths ./mach
+
+test:V:
+	go test . ./paths ./mach

--- a/path_test.go
+++ b/path_test.go
@@ -6,6 +6,9 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/forsyth/jsonpath/mach"
+	"github.com/forsyth/jsonpath/paths"
 )
 
 const testFile = "testdata/t1"
@@ -39,7 +42,7 @@ func TestPathParse(t *testing.T) {
 		if building {
 			fmt.Printf("%s -> ", sam)
 		}
-		path, err := ParsePath(sam)
+		path, err := paths.ParsePath(sam)
 		if err != nil {
 			if building {
 				fmt.Printf("!%s\n", err)
@@ -72,58 +75,10 @@ func TestPathParse(t *testing.T) {
 }
 
 // build a program for the Path and return a readable version as a string
-func codePath(path Path) (string, error) {
-	prog, err := path.Compile()
+func codePath(path paths.Path) (string, error) {
+	prog, err := mach.Compile(path)
 	if err != nil {
 		return "", err
 	}
-	return progString(prog), nil
-}
-
-func progString(prog *Program) string {
-	var sb strings.Builder
-	for i, val := range prog.vals {
-		if i > 0 {
-			sb.WriteByte(' ')
-		}
-		sb.WriteString(val.String())
-	}
-	if len(prog.vals) > 0 {
-		sb.WriteByte(' ')
-	}
-	for i, ord := range prog.orders {
-		if i > 0 {
-			sb.WriteByte(' ')
-		}
-		op := ord.op()
-		sb.WriteString(trimOp(op))
-		if op.IsLeaf() {
-			if !op.HasVal() {
-				continue
-			}
-			if ord.isSmallInt() {
-				sb.WriteByte('(')
-				sb.WriteString(fmt.Sprint(ord.smallInt()))
-				sb.WriteByte(')')
-			} else {
-				sb.WriteByte('[')
-				sb.WriteString(fmt.Sprint(ord.index()))
-				sb.WriteByte(']')
-			}
-			continue
-		}
-		if ord.isSmallInt() && ord.smallInt() != 0 {
-			sb.WriteByte('.')
-			sb.WriteString(fmt.Sprint(ord.smallInt()))
-		}
-	}
-	return sb.String()
-}
-
-func trimOp(op Op) string {
-	name := opNames[op]
-	if name == "" {
-		panic("unknown op in opNames")
-	}
-	return name[2:]
+	return prog.String(), nil
 }

--- a/paths/doc.go
+++ b/paths/doc.go
@@ -2,7 +2,7 @@
 // Usable under the terms in the file LICENSE.
 
 /*
-Package jsonpath provides a parser for JSONpaths, a syntax for expressing queries and locations in a JSON structure.
+Package jsonpath/paths provides a parser for JSONpaths, a syntax for expressing queries and locations in a JSON structure.
 
 The JSONpath syntax is often defined by providing a set of sample paths.
 Following https://github.com/dchester/jsonpath/, this package instead is based on a grammar,
@@ -24,4 +24,4 @@ Several threads can Run the same Program simultaneously, since each Run gets its
 
 (Components are still subject to change, since this is not yet an initial release.)
 */
-package jsonpath
+package paths

--- a/paths/expr.go
+++ b/paths/expr.go
@@ -1,4 +1,4 @@
-package jsonpath
+package paths
 
 // Elements of an expression tree (Expr)
 
@@ -24,15 +24,15 @@ type Expr interface {
 // Inner represents an interior operation with one or more operands.
 type Inner struct {
 	Op
-	kids []Expr
+	Kids []Expr
 }
 
 // Kid returns child c (index c) and true, or nil and false if the child doesn't exist.
 func (i *Inner) Kid(c int) (Expr, bool) {
-	if c >= len(i.kids) {
+	if c >= len(i.Kids) {
 		return nil, false
 	}
-	return i.kids[c], true
+	return i.Kids[c], true
 }
 
 func (i *Inner) String() string {

--- a/paths/json.go
+++ b/paths/json.go
@@ -1,0 +1,5 @@
+package paths
+
+// JSON is a synonym for the interface{} structures returned by encoding/json,
+// used as values in the JSON machine, to make it clear that's what they are.
+type JSON = interface{}

--- a/paths/lex.go
+++ b/paths/lex.go
@@ -1,4 +1,4 @@
-package jsonpath
+package paths
 
 import (
 	"errors"

--- a/paths/lex_test.go
+++ b/paths/lex_test.go
@@ -1,4 +1,4 @@
-package jsonpath
+package paths
 
 import (
 	"fmt"

--- a/paths/lexexpr.go
+++ b/paths/lexexpr.go
@@ -1,4 +1,4 @@
-package jsonpath
+package paths
 
 import (
 	"errors"

--- a/paths/lexpath.go
+++ b/paths/lexpath.go
@@ -1,4 +1,4 @@
-package jsonpath
+package paths
 
 import "math"
 

--- a/paths/ops.go
+++ b/paths/ops.go
@@ -1,4 +1,4 @@
-package jsonpath
+package paths
 
 // Op represents path expression leaf and expression operators, and filter and expression engine operators.
 //

--- a/paths/parseexpr.go
+++ b/paths/parseexpr.go
@@ -1,4 +1,4 @@
-package jsonpath
+package paths
 
 // Parse the script expression language embedded within path expressions.
 // It's a small subset of JavaScript (at least I hope it's a small subset.)

--- a/paths/parsepath.go
+++ b/paths/parsepath.go
@@ -1,4 +1,4 @@
-package jsonpath
+package paths
 
 import (
 	"fmt"

--- a/paths/parser.go
+++ b/paths/parser.go
@@ -1,4 +1,4 @@
-package jsonpath
+package paths
 
 import "fmt"
 

--- a/paths/path.go
+++ b/paths/path.go
@@ -1,4 +1,4 @@
-package jsonpath
+package paths
 
 import (
 	"fmt"

--- a/paths/rd.go
+++ b/paths/rd.go
@@ -1,4 +1,4 @@
-package jsonpath
+package paths
 
 import "fmt"
 

--- a/paths/tokens.go
+++ b/paths/tokens.go
@@ -1,4 +1,4 @@
-package jsonpath
+package paths
 
 import "unicode/utf8"
 

--- a/paths/val.go
+++ b/paths/val.go
@@ -1,4 +1,4 @@
-package jsonpath
+package paths
 
 import (
 	"fmt"


### PR DESCRIPTION
Prompted by a suggestion by Roger Peppe, mimic regexp by having a top-level minimalist API for the common use and sub-packages for the detail. I did want people to be able to use the ParsePath and ParseExpr code separately from having to use the abstract machine to do the evaluation, since just parsing the stuff is work enough, nice to hand over to another package or (now) subpackage.